### PR TITLE
Update titles in K-Maker documentation

### DIFF
--- a/content/3.products/6.k-maker.md
+++ b/content/3.products/6.k-maker.md
@@ -41,7 +41,7 @@ K-Maker delivers four core capabilities that directly address the root causes of
 ::KCard
 Create and curate machine-readable vocabularies to replace fragmented lists with version-controlled definitional points-of-truth. K-Maker ships with the powerful [SKOS](https://www.w3.org/TR/skos-primer/) data model built-in allowing you to represent concepts in hieararcies with multiple annotations and provenance.
 #title
-A sophisticated vocabulary model
+Vocabulary model
 ::
 
 <div style="height:10px;">&nbsp;</div>
@@ -49,7 +49,7 @@ A sophisticated vocabulary model
 ::KCard
 K-Maker UIs are built using [SHACL (Shapes Constraint Language)](https://www.w3.org/TR/shacl12-core/) data definitions, ensuring every user interaction validates data against your required patterns at point of entry. Invalid data cannot enter your reference data store.
 #title
-SHACL UI with data integrity
+Data validation
 ::
 
 <div style="height:10px;">&nbsp;</div>
@@ -57,7 +57,7 @@ SHACL UI with data integrity
 ::KCard
 Formalised change and approval processes via a purpose-built web UI — with staging review, version control, and granular, role-based access. Every change is fully auditable from author edit through to production publication.
 #title
-Structured publishing workflows
+Publishing workflows
 ::
 
 <div style="height:10px;">&nbsp;</div>
@@ -65,7 +65,7 @@ Structured publishing workflows
 ::KCard
 Any downstream system can consume governed vocabularies via REST API or embeddable web components — in multiple formats including JSON-LD, Turtle, CSV and RDF/XML. Integrate once; all consumers benefit from every future vocabulary update automatically.
 #title
-Seamless system integration
+System integration
 ::
 
 ### How it works - from vocabulary pattern to Knowledge Graph


### PR DESCRIPTION
Update capability headings to improve scannability, front-load meaning, and let the body copy demonstrate technical depth (“show, don’t tell”).